### PR TITLE
Fix pasting of multiline .env formatted input

### DIFF
--- a/plugins/env/app/assets/javascripts/env/application.js
+++ b/plugins/env/app/assets/javascripts/env/application.js
@@ -5,7 +5,7 @@
     var obj = {};
 
     // convert Buffers before splitting into lines and processing
-    src.toString().split('\n').forEach(function (line) {
+    src.toString().split('\\n').forEach(function (line) {
       // matching "KEY' and 'VAL' in 'KEY=VAL'
       var keyValueArr = line.match(/^\s*([\w\.\-]+)\s*=\s*(.*)?\s*$/);
       // matched?


### PR DESCRIPTION
`prompt()` in javascript doesn't handle `\n` as newlines and doesn't work with `motdotla/dotenv`'s implementation for `parseEnv()`


### BEFORE FIX:

```
parseEnv(prompt()) -> {HELLO: "world"\nYOUARE="great"}
```

### AFTER FIX:

```
parseEnv(prompt()) -> {HELLO: "world", YOUARE: "great"}
```

Affected feature: https://github.com/zendesk/samson/pull/1997

/cc @zendesk/samson

### Risks
- Level: Low
